### PR TITLE
Pass "compression" to WinSCP [v2]

### DIFF
--- a/kitty.c
+++ b/kitty.c
@@ -4038,7 +4038,7 @@ void StartWinSCP( HWND hwnd, char * directory, char * host, char * user ) {
 		if( strlen(conf_get_str(conf,CONF_proxy_username))>0 ) { strcat( cmd, " ProxyUsername=" ) ; strcat( cmd, conf_get_str(conf,CONF_proxy_username) ) ; }
 		if( strlen(conf_get_str(conf,CONF_proxy_password))>0 ) { strcat( cmd, " ProxyPassword=" ) ; strcat( cmd, conf_get_str(conf,CONF_proxy_password) ) ; }
 	}
-	if( conf_get_int(conf,CONF_compression) > 1 ) {
+	if( conf_get_int(conf,CONF_compression) ) {
 		if( raw == 0 ) {
 			strcat( cmd, " -rawsettings" ) ;
 			raw++;

--- a/kitty.c
+++ b/kitty.c
@@ -3943,9 +3943,10 @@ Le chemin vers l'exécutable WinSCP est défini dans la variable WInSCPPath. Ell
 @ECHO OFF
 start "C:\Program Files\WinSCP\WinSCP.exe" "%1" "%2" "%3" "%4" "%5" "%6" "%7" "%8" "%9"
 */	
-// winscp.exe [(sftp|ftp|scp)://][user[:password]@]host[:port][/path/[file]] [/privatekey=key_file]
+// winscp.exe [(sftp|ftp|scp)://][user[:password]@]host[:port][/path/[file]] [/privatekey=key_file] [/rawsettings (ProxyMethod=1) (Compression=1)]
 void StartWinSCP( HWND hwnd, char * directory, char * host, char * user ) {
 	char cmd[4096], shortpath[1024], buffer[4096], proto[10] ;
+	int raw = 0;
 	
 	if( directory == NULL ) { directory = kitty_current_dir(); } 
 	if( WinSCPPath==NULL ) {
@@ -4022,7 +4023,10 @@ void StartWinSCP( HWND hwnd, char * directory, char * host, char * user ) {
 			}
 	}
 	if( conf_get_int(conf,CONF_proxy_type)!=I(PROXY_NONE) ) {
-		strcat( cmd, " -rawsettings" ) ;
+		if( raw == 0 ) {
+			strcat( cmd, " -rawsettings" ) ;
+			raw++;
+			}
 		switch( conf_get_int(conf,CONF_proxy_type) ) {
 			case 2: strcat( cmd, " ProxyMethod=2" ) ; break ;
 			case 3: strcat( cmd, " ProxyMethod=3" ) ; break ;
@@ -4033,6 +4037,13 @@ void StartWinSCP( HWND hwnd, char * directory, char * host, char * user ) {
 		sprintf( buffer, " ProxyPort=%d", conf_get_int(conf,CONF_proxy_port)) ; strcat( cmd, buffer ) ;
 		if( strlen(conf_get_str(conf,CONF_proxy_username))>0 ) { strcat( cmd, " ProxyUsername=" ) ; strcat( cmd, conf_get_str(conf,CONF_proxy_username) ) ; }
 		if( strlen(conf_get_str(conf,CONF_proxy_password))>0 ) { strcat( cmd, " ProxyPassword=" ) ; strcat( cmd, conf_get_str(conf,CONF_proxy_password) ) ; }
+	}
+	if( conf_get_int(conf,CONF_compression) > 1 ) {
+		if( raw == 0 ) {
+			strcat( cmd, " -rawsettings" ) ;
+			raw++;
+			}
+		strcat( cmd, " Compression=1" ) ;
 	}
 	
 	if( debug_flag ) { debug_logevent( "Run: %s", cmd ) ; }


### PR DESCRIPTION
Pass the parameter "-rawsettings Compression=1" to WinSCP when the compression is enabled.

Note: Compatible with other "rawsettings" like ProxyMethod
Note2: Supersedes PR #11 .