### PR TITLE
Add support of cursor style DECSCUSR (changing of cursor shapes)

### DIFF
--- a/0.73_My_PuTTY/terminal.c
+++ b/0.73_My_PuTTY/terminal.c
@@ -3338,6 +3338,7 @@ unsigned long term_translate(
     return c;
 }
 
+extern int cursor_type;
 /*
  * Remove everything currently in `inbuf' and stick it up on the
  * in-memory display. There's a big state machine in here to
@@ -3887,6 +3888,18 @@ static void term_out(Terminal *term)
 		    if (term->esc_nargs < ARGS_MAX)
 			term->esc_args[term->esc_nargs++] = ARG_DEFAULT;
 		    term->termstate = SEEN_CSI;
+		} else if (c == 'q') {
+		    // cursor shape type (DECSCUSR)
+		    int cursor_shape = def(term->esc_args[0], 1);
+		    // set cursor_type from shape (cursor_type: 0=block, 1=underline, 2=beam)
+		    cursor_type = (cursor_shape - 1) >> 1;
+		    // set term->blink_cur from shape (odd numbers indicate blinking in DECSCUSR)
+		    if (term->blink_cur != cursor_shape & 1)
+		    {
+			term->blink_cur = cursor_shape & 1;
+			term_reset_cblink(term);
+		    }
+		    term->termstate = TOPLEVEL;
 		} else if (c < '@') {
 		    if (term->esc_query)
 			term->esc_query = -1;


### PR DESCRIPTION
Support changing of cursor shapes and blinking via XTerm escape sequences (block/beam/underscore with or without blinking).