### PR TITLE
Fix far2l extensions support

### DIFF
--- a/0.76_My_PuTTY/settings.c
+++ b/0.76_My_PuTTY/settings.c
@@ -1295,7 +1295,7 @@ void load_open_settings(settings_r *sesskey, Conf *conf)
     gppb(sesskey, "HideMousePtr", false, conf, CONF_hide_mouseptr);
     gppb(sesskey, "SunkenEdge", false, conf, CONF_sunken_edge);
     gppi(sesskey, "WindowBorder", 1, conf, CONF_window_border);
-#ifdef DMOD_FAR2L
+#ifdef MOD_FAR2L
     gppi(sesskey, "CurType", 1, conf, CONF_cursor_type);
     gppb(sesskey, "BlinkCur", true, conf, CONF_blink_cur);
 #else

--- a/0.76_My_PuTTY/terminal.c
+++ b/0.76_My_PuTTY/terminal.c
@@ -15,8 +15,8 @@
 
 #ifdef MOD_FAR2L
 /* base64 library - needed for far2l extensions support */
-#include <windows/cencode.h>
-#include <windows/cdecode.h>
+#include <../far2l/cencode.h>
+#include <../far2l/cdecode.h>
 #endif
 #ifdef MOD_PERSO
 #include "charset.h"
@@ -3280,7 +3280,7 @@ static void do_osc(Terminal *term)
                     // until implementing dynamic osc_string allocation
 
                     #ifdef _WINDOWS
-                    MessageBox(wgs.term_hwnd, "Too large clipboard :(", "Error", MB_OK);
+                    MessageBox(NULL, "Too large clipboard :(", "Error", MB_OK);
                     #endif
 
                     // correct request id is lost forever
@@ -3339,13 +3339,13 @@ static void do_osc(Terminal *term)
                             NOTIFYICONDATAW pnid;
                             // todo: do this on window focus also
                             pnid.cbSize = sizeof(pnid);
-                            pnid.hWnd = wgs.term_hwnd;
+                            pnid.hWnd = NULL;
                             pnid.hIcon = LoadIcon(0, IDI_APPLICATION);
                             pnid.uID = 200;
                             Shell_NotifyIconW(NIM_DELETE, &pnid);
                             // todo: use putty icon
                             pnid.cbSize = sizeof(pnid);
-                            pnid.hWnd = wgs.term_hwnd;
+                            pnid.hWnd = NULL;
                             pnid.hIcon = LoadIcon(0, IDI_APPLICATION);
                             pnid.uID = 200;
                             pnid.uFlags = NIF_ICON | NIF_INFO | NIF_MESSAGE;
@@ -3413,7 +3413,7 @@ static void do_osc(Terminal *term)
                                 #ifdef _WINDOWS
                                 char ec_status = 0;
                                 if (term->clip_allowed == 1) {
-                                    OpenClipboard(wgs.term_hwnd);
+                                    OpenClipboard(NULL);
                                     ec_status = EmptyClipboard() ? 1 : 0;
                                     CloseClipboard();
                                 }
@@ -3464,7 +3464,7 @@ static void do_osc(Terminal *term)
 
                                 #ifdef _WINDOWS
                                 if (term->clip_allowed == -1) {
-                                    int status = MessageBox(wgs.term_hwnd,
+                                    int status = MessageBox(NULL,
                                         "Allow far2l clipboard sync?", "PyTTY", MB_OKCANCEL);
                                     if (status == IDOK) {
                                         term->clip_allowed = 1;
@@ -3546,7 +3546,7 @@ static void do_osc(Terminal *term)
                                             memcpy(GData,buffer,BufferSize);
                                             GlobalUnlock(hData);
 
-                                            if (OpenClipboard(wgs.term_hwnd)) {
+                                            if (OpenClipboard(NULL)) {
 
                                                 if (!SetClipboardData(fmt, (HANDLE)hData)) {
                                                     GlobalFree(hData);
@@ -3605,7 +3605,7 @@ static void do_osc(Terminal *term)
                                     int32_t ClipTextSize = 0;
 
                                     if ((gfmt == CF_TEXT || gfmt == CF_UNICODETEXT || gfmt >= 0xC000) &&
-                                        OpenClipboard(wgs.term_hwnd))
+                                        OpenClipboard(NULL))
                                     {
                                         HANDLE hClipData = GetClipboardData((gfmt == CF_TEXT) ? CF_UNICODETEXT : gfmt);
 

--- a/0.76_My_PuTTY/terminal.c
+++ b/0.76_My_PuTTY/terminal.c
@@ -13,7 +13,7 @@
 #include "putty.h"
 #include "terminal.h"
 
-#ifdef DMOD_FAR2L
+#ifdef MOD_FAR2L
 /* base64 library - needed for far2l extensions support */
 #include <windows/cencode.h>
 #include <windows/cdecode.h>
@@ -2005,7 +2005,7 @@ Terminal *term_init(Conf *myconf, struct unicode_data *ucsdata, TermWin *win)
      * that need it.
      */
     term = snew(Terminal);
-#ifdef DMOD_FAR2L
+#ifdef MOD_FAR2L
     /* far2l */
     term->far2l_ext = 0; // far2l extensions mode is enabled?
     term->is_apc = 0; // currently processing incoming APC sequence?
@@ -3215,7 +3215,7 @@ static void toggle_mode(Terminal *term, int mode, int query, bool state)
  */
 static void do_osc(Terminal *term)
 {
-#ifdef DMOD_FAR2L
+#ifdef MOD_FAR2L
     /* far2l extensions support */
     if (term->is_apc) {
 
@@ -4689,7 +4689,7 @@ static void term_out(Terminal *term)
 		    term->esc_args[0] = ARG_DEFAULT;
 		    term->esc_query = 0;
 		    break;
-#ifdef DMOD_FAR2L
+#ifdef MOD_FAR2L
 		case '_': /* far2l: processing APC is almost the same as processing OSC */
              term->is_apc = 1;
              //break;
@@ -5922,7 +5922,7 @@ static void term_out(Terminal *term)
                     } else {
                         term->termstate = OSC_STRING;
                         term->osc_strlen = 0;
-#ifdef DMOD_FAR2L
+#ifdef MOD_FAR2L
                         /* far2l */
                         if (term->is_apc) {
                             term->osc_string[term->osc_strlen++] = (char)c;

--- a/0.76_My_PuTTY/terminal.h
+++ b/0.76_My_PuTTY/terminal.h
@@ -185,7 +185,7 @@ struct terminal_tag {
 #define ANSI(x,y)	((x)+((y)*256))
 #define ANSI_QUE(x)	ANSI(x,1)
 
-#ifdef DMOD_FAR2L
+#ifdef MOD_FAR2L
 /* far2l extensions support */
 //#define OSC_STR_MAX 2048
 // todo: allocate osc_string dynamically
@@ -197,7 +197,7 @@ struct terminal_tag {
     char osc_string[OSC_STR_MAX + 1];
     bool osc_w;
 
-#ifdef DMOD_FAR2L
+#ifdef MOD_FAR2L
     /* far2l */
     int far2l_ext; // extensions mode on
     bool is_apc; // currently processing APC sequence
@@ -219,7 +219,7 @@ struct terminal_tag {
 
 	SEEN_OSC_P,
 	OSC_STRING, OSC_MAYBE_ST,
-#ifdef DMOD_FAR2L
+#ifdef MOD_FAR2L
     /* far2l extensions support */ SEEN_APC,
     VT52_ESC,
 #else

--- a/0.76_My_PuTTY/windows/window.c
+++ b/0.76_My_PuTTY/windows/window.c
@@ -442,7 +442,7 @@ int WINAPI Agent_WinMain(HINSTANCE inst, HINSTANCE prev, LPSTR cmdline, int show
 
 #endif
 #ifdef MOD_WTS
-//typedef enum _WTS_VIRTUAL_CLASS { WTSVirtualClientData, WTSVirtualFileHandle } WTS_VIRTUAL_CLASS; 		// WTS_VIRTUAL_CLASS is not definned in file wtsapi32.h !!!
+typedef enum _WTS_VIRTUAL_CLASS { WTSVirtualClientData, WTSVirtualFileHandle } WTS_VIRTUAL_CLASS; 		// WTS_VIRTUAL_CLASS is not definned in file wtsapi32.h !!!
 #include <wtsapi32.h>
 #endif
 #if (defined MOD_BACKGROUNDIMAGE) && (!defined FLJ)

--- a/0.76_My_PuTTY/windows/window.c
+++ b/0.76_My_PuTTY/windows/window.c
@@ -10,7 +10,7 @@
 #include <limits.h>
 #include <assert.h>
 
-#ifdef DMOD_FAR2L
+#ifdef MOD_FAR2L
 /* far2l extensions support - base64 encode/decode libs */
 #include <cencode.h>
 #include <cdecode.h>
@@ -618,7 +618,7 @@ static const SeatVtable win_seat_vt = {
     .interactive = nullseat_interactive_yes,
     .get_cursor_position = win_seat_get_cursor_position,
 };
-#ifdef DMOD_FAR2L
+#ifdef MOD_FAR2L
 // "static" removed by far2l extensions support patch
 // we need to access wgs from terminal.c to open dialog boxes, etc
 WinGuiSeat wgs = { .seat.vt = &win_seat_vt,
@@ -4843,7 +4843,7 @@ free(cmd);
 	ignore_clip = wParam;	       /* don't panic on DESTROYCLIPBOARD */
 	break;
       case WM_DESTROYCLIPBOARD:
-#ifdef DMOD_FAR2L
+#ifdef MOD_FAR2L
         /* far2l extensions support */
 
         // In far2l extensions mode we should not do anything here,
@@ -5620,7 +5620,7 @@ if( (GetKeyState(VK_MENU)&0x8000) && (wParam==VK_SPACE) ) {
 	 * number noise.
 	 */
 	noise_ultralight(NOISE_SOURCE_KEY, lParam);
-#ifdef DMOD_FAR2L
+#ifdef MOD_FAR2L
   /* far2l extensions support */
     if (term->far2l_ext) {
 

--- a/0.76_My_PuTTY/windows/window.c
+++ b/0.76_My_PuTTY/windows/window.c
@@ -12,8 +12,8 @@
 
 #ifdef MOD_FAR2L
 /* far2l extensions support - base64 encode/decode libs */
-#include <cencode.h>
-#include <cdecode.h>
+#include <../../far2l/cencode.h>
+#include <../../far2l/cdecode.h>
 #endif
 
 #ifdef __WINE__
@@ -442,7 +442,7 @@ int WINAPI Agent_WinMain(HINSTANCE inst, HINSTANCE prev, LPSTR cmdline, int show
 
 #endif
 #ifdef MOD_WTS
-typedef enum _WTS_VIRTUAL_CLASS { WTSVirtualClientData, WTSVirtualFileHandle } WTS_VIRTUAL_CLASS; 		// WTS_VIRTUAL_CLASS is not definned in file wtsapi32.h !!!
+//typedef enum _WTS_VIRTUAL_CLASS { WTSVirtualClientData, WTSVirtualFileHandle } WTS_VIRTUAL_CLASS; 		// WTS_VIRTUAL_CLASS is not definned in file wtsapi32.h !!!
 #include <wtsapi32.h>
 #endif
 #if (defined MOD_BACKGROUNDIMAGE) && (!defined FLJ)

--- a/0.76_My_PuTTY/windows/winseat.h
+++ b/0.76_My_PuTTY/windows/winseat.h
@@ -3,7 +3,7 @@
  * and windlg.c.
  */
 
-#ifdef DMOD_FAR2L
+#ifdef MOD_FAR2L
 #pragma once
 #endif
 typedef struct WinGuiSeat WinGuiSeat;

--- a/far2l/cdecode.c
+++ b/far2l/cdecode.c
@@ -1,4 +1,4 @@
-#ifdef DMOD_FAR2L
+#ifdef MOD_FAR2L
 /*
 cdecoder.c - c source to a base64 decoding algorithm implementation
 This is part of the libb64 project, and has been placed in the public domain.

--- a/far2l/cdecode.h
+++ b/far2l/cdecode.h
@@ -1,4 +1,4 @@
-#ifdef DMOD_FAR2L
+#ifdef MOD_FAR2L
 /*
 cdecode.h - c header for a base64 decoding algorithm
 This is part of the libb64 project, and has been placed in the public domain.

--- a/far2l/cencode.c
+++ b/far2l/cencode.c
@@ -1,4 +1,4 @@
-#ifdef DMOD_FAR2L
+#ifdef MOD_FAR2L
 /*
 cencoder.c - c source to a base64 encoding algorithm implementation
 This is part of the libb64 project, and has been placed in the public domain.

--- a/far2l/cencode.h
+++ b/far2l/cencode.h
@@ -1,4 +1,4 @@
-#ifdef DMOD_FAR2L
+#ifdef MOD_FAR2L
 /*
 cencode.h - c header for a base64 encoding algorithm
 This is part of the libb64 project, and has been placed in the public domain.

--- a/kitty_settings.c
+++ b/kitty_settings.c
@@ -759,7 +759,7 @@ void load_open_settings_forced(char *filename, Conf *conf) {
     gppb_forced(sesskey, "HideMousePtr", false, conf, CONF_hide_mouseptr);
     gppb_forced(sesskey, "SunkenEdge", false, conf, CONF_sunken_edge);
     gppi_forced(sesskey, "WindowBorder", 1, conf, CONF_window_border);
-#ifdef DMOD_FAR2L
+#ifdef MOD_FAR2L
     gppi_forced(sesskey, "CurType", 1, conf, CONF_cursor_type);
     gppb_forced(sesskey, "BlinkCur", true, conf, CONF_blink_cur);
 #else


### PR DESCRIPTION
Some minor problems prevented far2l terminal extensions supports from actually working in KiTTY. This PR fixes them.