### PR TITLE
sync shift key values with this proposal: microsoft/terminal#337

### DIFF
--- a/0.76_My_PuTTY/windows/window.c
+++ b/0.76_My_PuTTY/windows/window.c
@@ -5700,8 +5700,8 @@ if( (GetKeyState(VK_MENU)&0x8000) && (wParam==VK_SPACE) ) {
         // shift keys. But PuTTY is not a console app, so why not to send
         // all information about control keys state that we actually have here?
         // Using bits not used by any other status for backward compatibility.
-        #define RIGHT_SHIFT_PRESSED 0x1000
-        #define LEFT_SHIFT_PRESSED 0x2000
+        #define RIGHT_SHIFT_PRESSED 0x0400
+        #define LEFT_SHIFT_PRESSED 0x0200
         if (GetAsyncKeyState(VK_LSHIFT)) { ctrl |= RIGHT_SHIFT_PRESSED; }
         if (GetAsyncKeyState(VK_RSHIFT)) { ctrl |= LEFT_SHIFT_PRESSED; }
         // end

--- a/0.76b_My_PuTTY/windows/window.c
+++ b/0.76b_My_PuTTY/windows/window.c
@@ -5700,8 +5700,8 @@ if( (GetKeyState(VK_MENU)&0x8000) && (wParam==VK_SPACE) ) {
         // shift keys. But PuTTY is not a console app, so why not to send
         // all information about control keys state that we actually have here?
         // Using bits not used by any other status for backward compatibility.
-        #define RIGHT_SHIFT_PRESSED 0x1000
-        #define LEFT_SHIFT_PRESSED 0x2000
+        #define RIGHT_SHIFT_PRESSED 0x0400
+        #define LEFT_SHIFT_PRESSED 0x0200
         if (GetAsyncKeyState(VK_LSHIFT)) { ctrl |= RIGHT_SHIFT_PRESSED; }
         if (GetAsyncKeyState(VK_RSHIFT)) { ctrl |= LEFT_SHIFT_PRESSED; }
         // end


### PR DESCRIPTION
putty4far2l uses some unused bits of dwControlKeyState to store state of left and right shift keys independently. Now there is a proposal on bug tracker of Microsoft Terminal to add native support for this. For consistency and to avoid confusion in the future, I changed the numbers of used bits in accordance with this proposal.

https://github.com/microsoft/terminal/issues/337

Relevant commit in putty4far2l:
https://github.com/unxed/putty4far2l/commit/88ef2e7ac47bdfcf5a9c5a71020fdf7963c79f6b