### PR TITLE
resolves #360: window closes if dns resolution fails after manual reconnect

### DIFF
--- a/0.76_My_PuTTY/windows/window.c
+++ b/0.76_My_PuTTY/windows/window.c
@@ -685,22 +685,23 @@ static void start_backend(void)
 		    start_backend() ;
 		    return ;
 		}
-	    } else {
+	    } else if( !is_backend_first_connected ) {
 	        MessageBox(NULL, msg, str, MB_OK);
 	    }
         }
 	sfree(str);
 	sfree(msg);
+	SetSSHConnected(0) ;
+	queue_toplevel_callback(close_session, NULL);
+	session_closed = true;
 	if( GetAutoreconnectFlag() && conf_get_int(conf,CONF_failure_reconnect) && is_backend_first_connected ) {
 	    SetConnBreakIcon(wgs.term_hwnd) ;
-	    SetSSHConnected(0) ;
-	    queue_toplevel_callback(close_session, NULL);
-	    session_closed = true;
 	    lp_eventlog(&wgs.logpolicy, "Unable to connect, trying to reconnect...") ; 
 	    SetTimer(wgs.term_hwnd, TIMER_RECONNECT, GetReconnectDelay()*1000, NULL) ; 
+	}
+	if( is_backend_first_connected ) {
 	    return ;
 	}
-	else
 #else
 	char *str = dupprintf("%s Error", appname);
         char *msg = dupprintf("Unable to open connection to\n%s\n%s",

--- a/0.76b_My_PuTTY/windows/window.c
+++ b/0.76b_My_PuTTY/windows/window.c
@@ -685,22 +685,23 @@ static void start_backend(void)
 		    start_backend() ;
 		    return ;
 		}
-	    } else {
+	    } else if( !is_backend_first_connected ) {
 	        MessageBox(NULL, msg, str, MB_OK);
 	    }
         }
 	sfree(str);
 	sfree(msg);
+	SetSSHConnected(0) ;
+	queue_toplevel_callback(close_session, NULL);
+	session_closed = true;
 	if( GetAutoreconnectFlag() && conf_get_int(conf,CONF_failure_reconnect) && is_backend_first_connected ) {
 	    SetConnBreakIcon(wgs.term_hwnd) ;
-	    SetSSHConnected(0) ;
-	    queue_toplevel_callback(close_session, NULL);
-	    session_closed = true;
 	    lp_eventlog(&wgs.logpolicy, "Unable to connect, trying to reconnect...") ; 
 	    SetTimer(wgs.term_hwnd, TIMER_RECONNECT, GetReconnectDelay()*1000, NULL) ; 
+	}
+	if( is_backend_first_connected ) {
 	    return ;
 	}
-	else
 #else
 	char *str = dupprintf("%s Error", appname);
         char *msg = dupprintf("Unable to open connection to\n%s\n%s",


### PR DESCRIPTION
start_backend() function (located in window.c) calls backend_init() that actually calls ssh_init() (ssh.c), that finally calls connect_to_host(). The last one does a synchronous DNS request, so if there's a DNS error, it would return an error. However (if DNS is OK), it sets up a new network connection asynchronously, therefore backend_init() would most likely return success even if the connection is going to fail a few milliseconds later.

There's a logic start_backend() that would display a message box and exit the program if backend_init() returns an error and FailureReconnect is not set, even if we are manually recovering a previously existing connection.

So the bug fix is to disable the message box and prevent calling exit(), also perform some de-initializations.