### PR TITLE
Resolves #475 Terminal window stops updating after resuming from sleep

### DIFF
--- a/0.76_My_PuTTY/timing.c
+++ b/0.76_My_PuTTY/timing.c
@@ -137,10 +137,12 @@ unsigned long schedule_timer(int ticks, timer_fn_t fn, void *ctx)
     }
 
     first = (struct timer *)index234(timers, 0);
-    if (first == t) {
+    if (first == t || first != NULL && first->now + 10 * (TICKSPERSEC) < now) {
 	/*
 	 * This timer is the very first on the list, so we must
 	 * notify the front end.
+	 * Also notify if the first timer has seriously missed its run time,
+	 * most likely due to a system sleep event.
 	 */
 	timer_change_notify(first->now);
     }

--- a/0.76b_My_PuTTY/timing.c
+++ b/0.76b_My_PuTTY/timing.c
@@ -137,10 +137,12 @@ unsigned long schedule_timer(int ticks, timer_fn_t fn, void *ctx)
     }
 
     first = (struct timer *)index234(timers, 0);
-    if (first == t) {
+    if (first == t || first != NULL && first->now + 10 * (TICKSPERSEC) < now) {
 	/*
 	 * This timer is the very first on the list, so we must
 	 * notify the front end.
+	 * Also notify if the first timer has seriously missed its run time,
+	 * most likely due to a system sleep event.
 	 */
 	timer_change_notify(first->now);
     }


### PR DESCRIPTION
Windows drops WM_TIMER during sleep that breaks schedule_timer().
Terminal window updates dependent on broken schedule_timer() do not work.
Fix schedule_timer().