### PR TITLE
Fixed cross-compilation on Linux; tray notifications support for far2l; fix far2l under Wine

### DIFF
--- a/0.76b_My_PuTTY/crypto/sha1.c
+++ b/0.76b_My_PuTTY/crypto/sha1.c
@@ -4,6 +4,10 @@
  *   http://csrc.nist.gov/cryptval/shs.html
  */
 
+#if defined(__i386__) 
+#define _FORCE_SOFTWARE_SHA=1
+#endif
+
 #include "ssh.h"
 #include <assert.h>
 
@@ -344,7 +348,9 @@ const ssh_hashalg ssh_sha1_sw = {
 
 #include <wmmintrin.h>
 #include <smmintrin.h>
+#if !defined(_FORCE_SOFTWARE_SHA)
 #include <immintrin.h>
+#endif
 #if defined(__clang__) || defined(__GNUC__)
 #include <shaintrin.h>
 #endif

--- a/0.76b_My_PuTTY/crypto/sha256.c
+++ b/0.76b_My_PuTTY/crypto/sha256.c
@@ -4,6 +4,10 @@
  *   http://csrc.nist.gov/cryptval/shs.html
  */
 
+#if defined(__i386__)
+#define _FORCE_SOFTWARE_SHA=1
+#endif
+
 #include "ssh.h"
 #include <assert.h>
 
@@ -360,7 +364,9 @@ const ssh_hashalg ssh_sha256_sw = {
 
 #include <wmmintrin.h>
 #include <smmintrin.h>
+#if !defined(_FORCE_SOFTWARE_SHA)
 #include <immintrin.h>
+#endif
 #if defined(__clang__) || defined(__GNUC__)
 #include <shaintrin.h>
 #endif

--- a/0.76b_My_PuTTY/terminal/terminal.h
+++ b/0.76b_My_PuTTY/terminal/terminal.h
@@ -202,6 +202,8 @@ struct terminal_tag {
     int far2l_ext; // extensions mode on
     bool is_apc; // currently processing APC sequence
     int clip_allowed; // remote clipboard access is allowed
+    DWORD prev_uchar;
+    HWND notif_hwnd;
 #endif
 
     char id_string[1024];

--- a/0.76b_My_PuTTY/windows/MAKEFILE.MINGW
+++ b/0.76b_My_PuTTY/windows/MAKEFILE.MINGW
@@ -104,7 +104,7 @@ RC = $(TOOLPATH)windres
 
 # CFLAGS = -Wall -O2 -std=gnu99 -Wvla -D_WINDOWS -DWIN32S_COMPAT \
 
-CFLAGS = -Wall -O2 -std=gnu99 -Wvla -D_WINDOWS -DWIN32S_COMPAT \
+CFLAGS = -Wall -O2 -std=gnu99 -Wvla -D_WINDOWS -DWIN32S_COMPAT -fcommon \
 		-D_NO_OLDNAMES -D__USE_MINGW_ANSI_STDIO=1 -I.././ \
 		-I../charset/ -I../windows/ -I../unix/ -I../crypto/ -I../proxy/ -I../ssh/ -I../terminal/ -I../utils/
 LDFLAGS = -s

--- a/0.76b_My_PuTTY/windows/window.c
+++ b/0.76b_My_PuTTY/windows/window.c
@@ -5724,11 +5724,24 @@ if( (GetKeyState(VK_MENU)&0x8000) && (wParam==VK_SPACE) ) {
         //int result = ToUnicode(wParam, MapVirtualKey(wParam, MAPVK_VK_TO_VSC), kb, uc, 4, 0);
         uchar = uc[0];
 
+        bool intl_uchar = uchar > 0x7F && uchar <= 0x10FFFF && !(uchar >= 0x80 && uchar <= 0x9F);
+
         // set event type
         if ((message == WM_KEYDOWN) || (message == WM_SYSKEYDOWN)) {
+
             type = 'K';
+
+            term->prev_uchar = uchar;
+
         } else {
+
             type = 'k';
+
+            // workaround for https://bugs.winehq.org/show_bug.cgi?id=57513
+            if (intl_uchar && (term->prev_uchar != uchar)) {
+                type = 'K';
+                term->prev_uchar = 0;
+            }
         }
 
         char* kev = malloc(15); // keyboard event structure length

--- a/0.76b_My_PuTTY/windows/window.c
+++ b/0.76b_My_PuTTY/windows/window.c
@@ -443,7 +443,8 @@ int WINAPI Agent_WinMain(HINSTANCE inst, HINSTANCE prev, LPSTR cmdline, int show
 
 #endif
 #ifdef MOD_WTS
-typedef enum _WTS_VIRTUAL_CLASS { WTSVirtualClientData, WTSVirtualFileHandle } WTS_VIRTUAL_CLASS; 		// WTS_VIRTUAL_CLASS is not definned in file wtsapi32.h !!!
+// This breaks cross-compilation on Linux. Anyway, this type is not actually used.
+//typedef enum _WTS_VIRTUAL_CLASS { WTSVirtualClientData, WTSVirtualFileHandle } WTS_VIRTUAL_CLASS; 		// WTS_VIRTUAL_CLASS is not definned in file wtsapi32.h !!!
 #include <wtsapi32.h>
 #endif
 #if (defined MOD_BACKGROUNDIMAGE) && (!defined FLJ)

--- a/kitty.c
+++ b/kitty.c
@@ -386,7 +386,7 @@ HWND GetMainHwnd(void) { return MainHwnd ; }
 // Decompte du nombre de fenetres en cours de KiTTY
 static int NbWindows = 0 ;
 
-NOTIFYICONDATA TrayIcone ;
+static NOTIFYICONDATA TrayIcone ;
 #define MYWM_NOTIFYICON		(WM_USER+3)
 
 #define TIMER_INIT 8701

--- a/kitty.h
+++ b/kitty.h
@@ -263,7 +263,7 @@ extern int AntiIdleCount ;
 extern int AntiIdleCountMax ;
 extern char AntiIdleStr[128] ;
 
-NOTIFYICONDATA TrayIcone ;
+static NOTIFYICONDATA TrayIcone ;
 #ifndef MYWM_NOTIFYICON
 #define MYWM_NOTIFYICON		(WM_USER+3)
 #endif


### PR DESCRIPTION
- Fixed cross-compilation on Linux via mingw (only 32 bit for now)
- System tray notifications support for far2l extensions
- Fixed far2l input mode if running under Wine
